### PR TITLE
Fix some issues with cross-platform building and TauriMobile building

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs-next = "2.0"
 
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["full"] }
 time = "0.3"
 url = "2.5"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -100,18 +100,6 @@ pub fn run() {
     }
 
     builder
-        .setup(|app| {
-            println!("[Desqta] Running setup, registering deep link handler...");
-
-            // Register all deep links unconditionally
-            {
-                use tauri_plugin_deep_link::DeepLinkExt;
-                let _ = app.deep_link().register_all();
-                println!("[Desqta] Registered all pre-defined deep links (unconditionally)");
-            }
-
-            Ok(())
-        })
         .invoke_handler(tauri::generate_handler![
             greet,
             netgrab::get_api_data,


### PR DESCRIPTION
1. OpenSSL-sys is a really bad crate and the rustls-tls feature + crate is a lot more stable.
2. `register_all()` is not a method on TauriMoble Deep Link.